### PR TITLE
Adds 100% specs for ecko plugins

### DIFF
--- a/ecko-plugins/Gemfile
+++ b/ecko-plugins/Gemfile
@@ -4,3 +4,11 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in ecko-plugins.gemspec
 gemspec
+
+group :test do
+  gem 'pry'
+  gem 'database_cleaner'
+  gem 'factory_bot'
+  gem 'faker', '~> 1.9.1'
+  gem 'simplecov'
+end

--- a/ecko-plugins/Gemfile.lock
+++ b/ecko-plugins/Gemfile.lock
@@ -67,10 +67,22 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     erubi (1.10.0)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    faker (1.9.6)
+      i18n (>= 0.7)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.8.11)
@@ -87,6 +99,9 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -131,6 +146,12 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -148,11 +169,17 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
+  database_cleaner
   ecko-plugins!
+  factory_bot
+  faker (~> 1.9.1)
+  pry
   rake (~> 13.0)
   rspec (~> 3.0)
+  simplecov
 
 BUNDLED WITH
-   2.3.3
+   2.3.4

--- a/ecko-plugins/spec/ecko/plugins_spec.rb
+++ b/ecko-plugins/spec/ecko/plugins_spec.rb
@@ -2,4 +2,16 @@ RSpec.describe Ecko::Plugins do
   it 'has a version number' do
     expect(Ecko::Plugins::VERSION).not_to be nil
   end
+
+  it 'has a way to register plugins' do
+    demo_schema = {
+      required_data: true
+    }
+
+    Ecko::Plugins.register(name: 'demo', schema: demo_schema, engine: DemoPlugin::Engine)
+
+    expect(Ecko::Plugins.demo).to eq Ecko::Plugins::Registry::Demo
+    expect(Ecko::Plugins.demo.configured_data).to eq 'Configured'
+    expect(Ecko::Plugins.registry['demo']).to be_present
+  end
 end

--- a/ecko-plugins/spec/spec_helper.rb
+++ b/ecko-plugins/spec/spec_helper.rb
@@ -1,9 +1,17 @@
+require 'simplecov'
+
+SimpleCov.start do
+  add_filter '/spec/'
+  minimum_coverage 90
+end
+
 require "bundler/setup"
 require "ecko/plugins"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/ecko-plugins/spec/spec_helper.rb
+++ b/ecko-plugins/spec/spec_helper.rb
@@ -5,13 +5,13 @@ SimpleCov.start do
   minimum_coverage 90
 end
 
-require "bundler/setup"
-require "ecko/plugins"
+require 'bundler/setup'
+require 'ecko/plugins'
+require 'specor/specor'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
-
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/ecko-plugins/spec/specor/demo_plugin.rb
+++ b/ecko-plugins/spec/specor/demo_plugin.rb
@@ -1,0 +1,17 @@
+# THis is a demo plugin module with its engine which will be registered in the registry
+module DemoPlugin
+  class Engine
+    @@configured_dummy_value = nil
+
+    class << self
+      def configure(_schema)
+        @@configured_dummy_value = 'Configured'
+        'Registration for the plugin is complete'
+      end
+
+      def configured_data
+        @@configured_dummy_value
+      end
+    end
+  end
+end

--- a/ecko-plugins/spec/specor/specor.rb
+++ b/ecko-plugins/spec/specor/specor.rb
@@ -1,0 +1,1 @@
+require_relative './demo_plugin'


### PR DESCRIPTION
Solves #6 
This pr now will make sure to have 90% or more spec for the plugin for CI purpose. This is ready for #5 as well. Now after this merge, we will have ecko-plugins as a global gem.